### PR TITLE
feat: no-throw-default-error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,6 @@ export const rules = {
   'invalid-cfn-imports': require('./rules/invalid-cfn-imports'),
   'no-literal-partition': require('./rules/no-literal-partition'),
   'no-invalid-path': require('./rules/no-invalid-path'),
+  'no-throw-default-error': require('./rules/no-throw-default-error'),
   'promiseall-no-unbounded-parallelism': require('./rules/promiseall-no-unbounded-parallelism'),
 };

--- a/src/rules/no-throw-default-error.ts
+++ b/src/rules/no-throw-default-error.ts
@@ -1,0 +1,52 @@
+import { Rule } from 'eslint';
+import type { NewExpression, ThrowStatement } from 'estree';
+
+export const meta = {
+  hasSuggestions: true,
+};
+
+export function create(context: Rule.RuleContext): Rule.NodeListener {
+  return {
+    ThrowStatement(node: ThrowStatement) {
+      if (node.argument.type !== 'NewExpression') {
+        return;
+      }
+
+      const newExpr = node.argument as NewExpression;
+      if (
+        newExpr.callee &&
+        newExpr.callee.type === 'Identifier' &&
+        newExpr.callee.name === 'Error'
+      ) {
+        context.report({
+          node: newExpr,
+          message: 'Expected a non-default error object to be thrown.',
+          suggest: [
+            {
+              desc: 'Replace with `ValidationError`',
+              fix: (fixer: Rule.RuleFixer) => {
+                // no existing args
+                if (newExpr.arguments.length === 0) {
+                  return fixer.replaceText(newExpr, "new ValidationError('<insert error message>', this)");
+                }
+
+                const fixes = [
+                  fixer.replaceText(newExpr.callee, 'ValidationError'),
+                ];
+
+                const last = newExpr.arguments.at(-1)?.range;
+                if (last) {
+                  fixes.push(
+                    fixer.insertTextAfterRange(last, ', this'),
+                  );
+                }
+
+                return fixes;
+              },
+            },
+          ],
+        });
+      }
+    },
+  };
+}

--- a/test/rules/fixtures/no-throw-default-error/error-no-args.suggested.ts
+++ b/test/rules/fixtures/no-throw-default-error/error-no-args.suggested.ts
@@ -1,0 +1,1 @@
+throw new ValidationError('<insert error message>', this);

--- a/test/rules/fixtures/no-throw-default-error/error-no-args.ts
+++ b/test/rules/fixtures/no-throw-default-error/error-no-args.ts
@@ -1,0 +1,1 @@
+throw new Error();

--- a/test/rules/fixtures/no-throw-default-error/error-one-arg.suggested.ts
+++ b/test/rules/fixtures/no-throw-default-error/error-one-arg.suggested.ts
@@ -1,0 +1,1 @@
+throw new ValidationError('My error', this);

--- a/test/rules/fixtures/no-throw-default-error/error-one-arg.ts
+++ b/test/rules/fixtures/no-throw-default-error/error-one-arg.ts
@@ -1,0 +1,1 @@
+throw new Error('My error');

--- a/test/rules/fixtures/no-throw-default-error/eslintrc.js
+++ b/test/rules/fixtures/no-throw-default-error/eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  plugins: ['local'],
+  rules: {
+    'local/no-throw-default-error': [ 'error' ],
+  }
+}
+
+

--- a/test/rules/fixtures/no-throw-default-error/throw-error.error.txt
+++ b/test/rules/fixtures/no-throw-default-error/throw-error.error.txt
@@ -1,0 +1,1 @@
+Expected a non-default error object to be thrown.

--- a/test/rules/fixtures/no-throw-default-error/throw-error.ts
+++ b/test/rules/fixtures/no-throw-default-error/throw-error.ts
@@ -1,0 +1,1 @@
+throw new Error('Some error');


### PR DESCRIPTION
A new rule to enforce using custom error types instead of the default error object.

<img width="802" alt="image" src="https://github.com/user-attachments/assets/b5e09529-7123-491a-af4c-942c5394e5d3">


Related to https://github.com/aws/aws-cdk/issues/32324